### PR TITLE
Fix iOS 14 Widget Update with Siri

### DIFF
--- a/MetroKit/Core Data/PersistentHistoryService.swift
+++ b/MetroKit/Core Data/PersistentHistoryService.swift
@@ -33,6 +33,7 @@ class PersistentHistoryService: NSObject {
             let history = historyResult.result as! [NSPersistentHistoryTransaction]
 
             let previousStalenessInterval = context.stalenessInterval
+            context.stalenessInterval = 0
             for transaction in history.reversed() {
                 context.mergeChanges(fromContextDidSave: transaction.objectIDNotification())
             }


### PR DESCRIPTION
On iOS 14, there was a bug where sometimes the user wouldn't see their new balance in the app or the widget, which would cause errors.

- Use 0 staleness interval when merging external changes to avoid displaying stale data
- Use Future when applying changes to avoid race conditions
